### PR TITLE
Gvaclassify signal

### DIFF
--- a/gst/inference_elements/gvaclassify/classification_history.h
+++ b/gst/inference_elements/gvaclassify/classification_history.h
@@ -49,6 +49,7 @@ struct ClassificationHistory {
     ClassificationHistory(GstGvaClassify *gva_classify);
 
     bool IsROIClassificationNeeded(GstVideoRegionOfInterestMeta *roi, uint64_t current_num_frame);
+    bool IsROIClassificationNeededDueToMeta(const GstVideoRegionOfInterestMeta *roi) const;
     void UpdateROIParams(int roi_id, const GstStructure *roi_param);
     void FillROIParams(GstBuffer *buffer);
 };

--- a/gst/inference_elements/gvaclassify/gstgvaclassify.c
+++ b/gst/inference_elements/gvaclassify/gstgvaclassify.c
@@ -156,7 +156,7 @@ void gst_gva_classify_class_init(GstGvaClassifyClass *gvaclassify_class) {
             DEFAULT_MIN_RECLASSIFY_INTERVAL, DEFAULT_MAX_RECLASSIFY_INTERVAL, DEFAULT_RECLASSIFY_INTERVAL,
             (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-    // Property that determines whether or not the "about-to-classify" signal
+    // Property that determines whether or not the "classify-roi" signal
     // should be raised before classifying a tracked object.
     g_object_class_install_property(
         gobject_class, PROP_SIGNAL_CLASSIFY_ROI,

--- a/gst/inference_elements/gvaclassify/gstgvaclassify.h
+++ b/gst/inference_elements/gvaclassify/gstgvaclassify.h
@@ -23,12 +23,19 @@ typedef struct _GstGvaClassify {
     // properties:
     gchar *object_class;
     guint reclassify_interval;
+    gboolean signal_classify_roi;
+
+    // Signals
+    guint signal_classify_roi_id;
 
     struct ClassificationHistory *classification_history;
 } GstGvaClassify;
 
 typedef struct _GstGvaClassifyClass {
     GvaBaseInferenceClass base_class;
+
+    // Declare class handler so that sub-classes have the ability to override it.
+    gboolean (*classify_roi) (GstElement *element, GstVideoRegionOfInterestMeta *roi);
 } GstGvaClassifyClass;
 
 GType gst_gva_classify_get_type(void);

--- a/gst/inference_elements/gvaclassify/pre_processors.cpp
+++ b/gst/inference_elements/gvaclassify/pre_processors.cpp
@@ -45,10 +45,15 @@ bool IsROIClassificationNeeded(GvaBaseInference *gva_base_inference, guint64 cur
         }
     }
 
-    // Check is object recently classified
     assert(gva_classify->classification_history != NULL);
-    return (gva_classify->reclassify_interval == 1 ||
-            gva_classify->classification_history->IsROIClassificationNeeded(roi, current_num_frame));
+    // If reclassification is possible on every interval, check the metadata to see
+    // if classification of this ROI should be skipped.
+    if (gva_classify->reclassify_interval == 1) {
+        return gva_classify->classification_history->IsROIClassificationNeededDueToMeta(roi);
+    }
+
+    // Check is object recently classified
+    return (gva_classify->classification_history->IsROIClassificationNeeded(roi, current_num_frame));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Added signal _classify-roi_ which may be issued for a tracked object (ROI) in one out of every _reclassify-interval_ frames prior to the ROI being classified.  The signal includes the metadata for the ROI. A signal subscriber may examine the ROI's metadata, and instruct gvaclassify to skip classfication of the ROI when classification is deemed unnecessary, e.g. ROI dimensions are too small. 

The return value from the last signal subscriber will indicate whether or not the ROI should be classified.

To maintain existing behaviour, the classify-roi signal will only be raised when the new property _signal-classify-roi_ is TRUE.  By default this property is FALSE.

To allow classification to be unaffected when there is no subscriber, a signal handler return value of FALSE indicates that classification should be run, and a return value of TRUE indicates that classification should be skipped.

As signal generation and handling is likely to be more expensive than examining variables local to gvaclassify, the emission of the signal is: 
+ delayed until it has been confirmed that classification will not be skipped due to the value of the _reclassify-interval_ property. 
+ made before various classification history variables are set when classification would ordinarily have occurred (see ClassificationHistory::IsROIClassificationNeeded)