### PR TITLE
yolov3 and v4 support rectangle input size

### DIFF
--- a/gst/inference_elements/gvadetect/converters/yolo_v3_base.h
+++ b/gst/inference_elements/gvadetect/converters/yolo_v3_base.h
@@ -14,15 +14,16 @@ class YOLOV3Converter : public YOLOConverter {
   protected:
     const std::map<size_t, std::vector<size_t>> masks;
     const size_t coords = 4;
-    const size_t input_size;
+    const size_t input_size_h;
+    const size_t input_size_w;
 
-    size_t entryIndex(size_t side, size_t location, size_t entry);
-    std::vector<float> softmax(const float *arr, size_t side, size_t common_offset, size_t size);
+    size_t entryIndex(size_t side_h, size_t side_w,  size_t location, size_t entry);
+    std::vector<float> softmax(const float *arr, size_t side_h, size_t side_w, size_t common_offset, size_t size);
 
   public:
     YOLOV3Converter(size_t classes_number, std::vector<float> anchors, std::map<size_t, std::vector<size_t>> masks,
                     size_t cells_number_x, size_t cells_number_y, double iou_threshold = 0.5,
-                    size_t bbox_number_on_cell = 3, size_t input_size = 416, bool do_cls_softmax = false,
+                    size_t bbox_number_on_cell = 3, size_t input_size_h = 416, size_t input_size_w = 416, bool do_cls_softmax = false,
                     bool output_sigmoid_activation = false);
 
     bool process(const std::map<std::string, InferenceBackend::OutputBlob::Ptr> &output_blobs,

--- a/samples/model_proc/yolo-v3-tf.json
+++ b/samples/model_proc/yolo-v3-tf.json
@@ -38,7 +38,8 @@
         2
       ],
       "bbox_number_on_cell": 3,
-      "cells_number": 13,
+      "cells_number_x": 13,
+      "cells_number_y": 13,
       "labels": [
         "person",
         "bicycle",

--- a/samples/model_proc/yolo-v4-tf.json
+++ b/samples/model_proc/yolo-v4-tf.json
@@ -40,7 +40,8 @@
         2
       ],
       "bbox_number_on_cell": 3,
-      "cells_number": 19,
+      "cells_number_x": 19,
+      "cells_number_y": 19,
       "labels": [
         "person",
         "bicycle",


### PR DESCRIPTION
I've test on my yolov4 model with input size 320x544, and the bboxes are correct.

Flag "cells_number" in model_proc now have to be "cells_number_x" and "cells_number_y"

Anchor mask will still only check cells_number_y to confirm the correct output layer, and I think it may be fine.

Yolov2 converter seems already support rectangle input, but I didn't test it.

TODO: Change all yolov2's sample model_proc to use "cells_number_x" and "cells_number_y"